### PR TITLE
Remove all content from ApiContracts.csproj

### DIFF
--- a/StileStreamWms/src/Products/StileStream.Wms.Products.ApiContracts/StileStream.Wms.Products.ApiContracts.csproj
+++ b/StileStreamWms/src/Products/StileStream.Wms.Products.ApiContracts/StileStream.Wms.Products.ApiContracts.csproj
@@ -1,9 +1,0 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-
-</Project>


### PR DESCRIPTION
The entire content of the `StileStream.Wms.Products.ApiContracts.csproj` file has been removed. This includes the project declaration, property group, target framework, implicit usings, and nullable settings.